### PR TITLE
Fix STM update type error

### DIFF
--- a/src/Reflex/Backend/WebSocket/Internal.hs
+++ b/src/Reflex/Backend/WebSocket/Internal.hs
@@ -21,6 +21,7 @@ import Data.Hashable (Hashable(..))
 import Control.Monad.STM
 import Control.Concurrent.STM.TVar
 import Control.Concurrent.STM.TBQueue
+import Numeric.Natural
 
 import qualified Control.Concurrent.STM.Map as SM
 
@@ -40,7 +41,7 @@ data WsData a =
 data WsManager a =
   WsManager (TVar Ticket) (TBQueue (WsData a)) (SM.Map Ticket ())
 
-mkWsManager :: Int -> STM (WsManager a)
+mkWsManager :: Natural -> STM (WsManager a)
 mkWsManager size =
   WsManager <$> newTVar (Ticket 0) <*> newTBQueue size <*> SM.empty
 


### PR DESCRIPTION
As of STM 4.5.0.0, `newTBQueue` now takes a `Numeric.Natural` size parameter instead of an `Int`, which causes a type error.

I'm not a Haskell master, and this fix would obviously break some code depending on it, so perhaps an alternative solution such as converting is more appropriate? 